### PR TITLE
fix: 移除浮動選單中的重複連結「罷免的理由」

### DIFF
--- a/reasonsRecall.html
+++ b/reasonsRecall.html
@@ -158,7 +158,6 @@ gtag('config', 'G-LCXFLLD9K2');
           <li><a href="ckfinder.html">🟢 民主連署站</a></li>
           <li><a href="https://linktr.ee/taiwanagainstccp?ltclid=9d7dbb0c-f9e4-4984-8a8c-dadacc1cfde2" target="_blank">🌏
               海外支持大罷免</a></li>
-          <li><a href="reasonsRecall.html">🧾 罷免的理由</a></li>
         </ul>
       </div>
   <script src="scripts/floatingMenu.js?v=20250406"></script>


### PR DESCRIPTION
fix: 移除浮動選單中的重複連結「罷免的理由」