### PR TITLE
feat: 新增 UAT 頁面及相關樣式和功能

### DIFF
--- a/indexUat.html
+++ b/indexUat.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta property="og:url" content="https://amaochen0110.github.io/Unseat/" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="全台大罷免第二階段連署時間條" />
+    <meta property="og:description" content="追蹤全台立委罷免第二階段連署進度，包含目前已執行天數、收件數、進度條與官方連署網址。" />
+    <meta property="og:image" content="https://amaochen0110.github.io/Unseat/images/Unseat.jpg?v=3" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <title>全台大罷免第二階段連署時間條</title>
+    <script type="application/ld+json">
+            {
+              "@context": "https://schema.org",
+              "@type": "Person",
+              "name": "阿貓",
+              "url": "https://amaochen0110.github.io/Unseat/",
+              "image": "https://amaochen0110.github.io/Unseat/images/amao.jpg",
+              "sameAs": [
+                "https://github.com/amaochen0110"
+              ]
+            }
+            </script>
+    <script type="application/ld+json">
+            {
+              "@context": "https://schema.org",
+              "@type": "WebSite",
+              "name": "全台大罷免第二階段連署時間條",
+              "url": "https://amaochen0110.github.io/Unseat/",
+              "logo": "https://amaochen0110.github.io/Unseat/images/amao.jpg",
+              "description": "追蹤全台立委罷免第二階段連署進度，包含目前已執行天數、收件數、進度條與官方連署網址。",
+              "keywords": [
+                "罷免立委",
+                "罷免進度",
+                "第二階段罷免",
+                "全台罷免",
+                "罷免收件數",
+                "罷免門檻",
+                "公民罷免",
+                "立法院罷免",
+                "連署書下載",
+                "罷免表單",
+                "選區罷免進度",
+                "實時罷免數據",
+                "罷免網址連結",
+                "新北市罷免",
+                "台北市罷免",
+                "桃園市罷免",
+                "台中市罷免",
+                "花蓮罷免",
+                "彰化罷免",
+                "南投罷免",
+                "雲林罷免",
+                "台東罷免",
+                "高雄罷免",
+                "基隆罷免",
+                "苗栗罷免",
+                "台灣罷免地圖",
+                "罷免進度條",
+                "罷免倒數",
+                "罷免收件進度",
+                "罷免連署查詢",
+                "全台罷免總覽",
+                "立委罷免追蹤",
+                "最新罷免消息",
+                "罷免站地點",
+                "罷免書怎麼填",
+                "罷免網站",
+                "罷免更新頻率",
+                "罷免志工",
+                "全民罷免行動",
+                "政治改革",
+                "民意反應",
+                "罷免工具",
+                "罷免平台",
+                "民主機制",
+                "第二階段連署",
+                "選區資訊查詢",
+                "罷免 PDF 表單",
+                "實體連署書"
+              ],
+              "inLanguage": "zh-TW",
+              "publisher": {
+                "@type": "Organization",
+                "name": "全台大罷免第二階段連署時間條",
+                "url": "https://amaochen0110.github.io/Unseat/"
+              },
+              "image": {
+                "@type": "ImageObject",
+                "url": "https://amaochen0110.github.io/Unseat/images/amao.jpg",
+                "width": 512,
+                "height": 512
+              },
+              "datePublished": "2025-03-21",
+              "dateModified": "2025-04-03"
+            }
+            </script>
+
+    <link rel="icon" href="images/favicon.png" type="image/png">
+    <link href="styles/styleUat.css" rel="stylesheet" />
+    <link href="styles/floatingMenu.css" rel="stylesheet" />
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-LCXFLLD9K2"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+
+        gtag('config', 'G-LCXFLLD9K2');
+    </script>
+</head>
+
+<body>
+    <div class="container">
+        <h1 id="current-date-title">全台大罷免第二階段連署時間條 <span class="hourglass">⌛</span></h1>
+        <p class="subtitle">扣除造冊及相關作業時間大約只有40天左右，還沒填寫的民眾請盡快前往填寫</p>
+
+        <p class="notice">
+            🔆本網站連署進度數據非即時更新，若與罷免團隊不同，請以各罷免團體公告為準。</br>
+            🔆目前顯示「統計中」之團隊尚未公開連署進度，實際資訊請以各罷免團體公告為準。
+        </p>
+
+        <div class="filter-sort">
+            <select name="filter" id="filter" class="general-select">
+                <option value="all">全部</option>
+                <option value="基隆市">基隆市</option>
+                <option value="新北市">新北市</option>
+                <option value="臺北市">臺北市</option>
+                <option value="桃園市">桃園市</option>
+                <option value="新竹市">新竹市</option>
+                <option value="新竹縣">新竹縣</option>
+                <option value="苗栗縣">苗栗縣</option>
+                <option value="臺中市">臺中市</option>
+                <option value="南投縣">南投縣</option>
+                <option value="彰化縣">彰化縣</option>
+                <option value="雲林縣">雲林縣</option>
+                <option value="花蓮縣">花蓮縣</option>
+                <option value="臺東縣">臺東縣</option>
+            </select>
+
+            <select name="sort" id="sort" class="general-select no-icon">
+                <option value="">預設排序</option>
+                <option value="targetNum-desc">目標進度▼</option>
+                <option value="targetNum-asc">目標進度▲</option>
+                <option value="threshold-desc">門檻進度▼</option>
+                <option value="threshold-asc">門檻進度▲</option>
+                <option value="startDate-asc">截止時間▼</option>
+                <option value="startDate-desc">截止時間▲</option>
+            </select>
+
+
+            <!-- <div class="sort-process">
+                <span>連署進度</span>
+                <span class="sort-icon">
+                    <span class="icon icon-sort">⇅</span>
+                    <span class="icon icon-up" style="display:none;">▲</span>
+                    <span class="icon icon-down" style="display:none;">▼</span>
+                </span>
+            </div> -->
+        </div>
+
+        <div class="person-list" id="person-list">
+            <!-- Person data will be populated here -->
+        </div>
+
+        <div class="info-section">
+            <div class="info-title">
+                <span class="sun">☀</span> 請注意以下事項：
+            </div>
+            <div class="info-grid">
+                <div class="info-item">
+                    <span class="check-mark">✓</span>
+                    <div><span class="important">重要!! 關於罷免任何消息請依<br>各選區公民罷免團體官方公佈為主!!</span></div>
+                </div>
+
+                <div class="info-item">
+                    <span class="check-mark">✓</span>
+                    <div>公民罷免團體公佈的認證地點或就近民進黨黨部及民代服務處</div>
+                </div>
+
+                <div class="info-item">
+                    <span class="check-mark">✓</span>
+                    <div>穿背心的罷團志工</div>
+                </div>
+
+                <div class="info-item">
+                    <span class="check-mark">✓</span>
+                    <div>要帶身份證+印章<br>(身份證為對照填寫資料用)</div>
+                </div>
+
+                <div class="info-item">
+                    <span class="check-mark">✓</span>
+                    <div><span class="important">寫過第一階段的要再出來<br>填寫第二階段(格式不同)</span></div>
+                </div>
+
+                <div class="info-item">
+                    <span class="check-mark">✓</span>
+                    <div>軍公教可以出來簽罷免了</div>
+                </div>
+
+                <div class="info-item">
+                    <span class="check-mark">✓</span>
+                    <div>罷免連署書必須使用罷團<br>提供的紙本或罷團網站提<br>供的檔案(PDF電子檔)</div>
+                </div>
+
+                <div class="info-item">
+                    <span class="cross-mark">✗</span>
+                    <div>不需附身份證影本</div>
+                </div>
+
+                <div class="info-item">
+                    <span class="cross-mark">✗</span>
+                    <div>並無線上填寫罷免連署，<br>罷免連署書一定要紙本交<br>給罷團後才算連署完成</div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- Floating Menu Button -->
+    <div id="floating-menu">MENU</div>
+    <div id="floating-panel">
+        <ul class="floating-panel-list">
+            <li><a href="ckfinder.html">🟢 民主連署站</a></li>
+            <li><a href="reasonsRecall.html">🧾 罷免的理由</a></li>
+            <li><a href="complimentSquad.html">🎉 誇誇計數器</a></li>
+            <li><a href="https://linktr.ee/taiwanagainstccp?ltclid=9d7dbb0c-f9e4-4984-8a8c-dadacc1cfde2" target="_blank">🌏 海外支持大罷免</a></li>
+            <!-- <li><a href="https://recall2025.ourtaiwan.tw/" target="_blank">🛠️ 罷免連署工具網站</a></li>
+            <li><a href="https://www.twacda.com/" target="_blank">🗺️ 罷免選區整合網站</a></li> -->
+            <!-- <li><a href="#">🌿 第二階段說明</a></li>
+            <li><a href="#">🌱 進度概況</a></li>
+            <li><a href="#">🏡 找連署點</a></li>
+            <li><a href="#">📜 表單下載</a></li> -->
+        </ul>
+    </div>
+    <script src="scripts/mainUat.js?v=20250406"></script>
+    <script src="scripts/floatingMenu.js?v=20250406"></script>
+</body>
+
+</html>

--- a/scripts/mainUat.js
+++ b/scripts/mainUat.js
@@ -1,0 +1,564 @@
+document.addEventListener('DOMContentLoaded', function () {
+    // Get current date when the page loads
+    const currentDate = new Date();
+    currentDate.setHours(0, 0, 0, 0);
+
+    // Format the current date for display
+    const formattedDate = `${currentDate.getFullYear()}/${currentDate.getMonth() + 1}/${currentDate.getDate()}`;
+
+    // Update the title with current date
+    document.getElementById('current-date-title').innerHTML =
+        `${formattedDate} 全台大罷免第二階段連署時間條 <span class="hourglass">⌛</span>`;
+
+    // Calculate days difference (current day is day 1, next day is day 2, etc.)
+    const calculateDayDifference = (person) => {
+        // If hasn't started yet
+        if (person.status === '還未開始') {
+            return { day: person.status, progress: 0 };
+        }
+
+        // 使用 Math.abs() 確保不會有負數
+        const diffTime = Math.abs(currentDate - new Date(person.startDate));
+
+        // 使用 Math.ceil() 並加1，確保換日即算一天
+        const currentDay = Math.ceil(diffTime / (1000 * 60 * 60 * 24)) + 1;
+
+        // Ensure we don't exceed 40 days
+        const finalDay = Math.min(currentDay, person.totalDays);
+
+        return {
+            day: `第${currentDay}天`,
+            progress: (finalDay / person.totalDays) * 100
+        };
+    };
+
+    // data
+    let originalPersonData = []
+    let personData = []
+
+    // 使用 fetch 讀取 personData.json
+    fetch('personData.json')
+        .then(response => response.json())
+        .then(data => {
+            personData = data;
+            fetchCountData();
+        });
+
+    function fetchCountData() {
+        fetch('https://docs.google.com/spreadsheets/d/e/2PACX-1vQ1vJG_0a6Dl0UoEwjMBjJkfzHKjlVhu-gajL-RRTYP4rw9ocZiXT7xQAXy97Hv78xi5-2YYlZikpyM/pub?gid=0&single=true&output=csv')
+            .then(response => response.text())
+            .then(csvData => {
+                const rows = csvData.split('\n').map(row => row.split(',').map(cell => cell.trim()));
+
+                const nameToCountMap = {};
+                for (let i = 0; i < rows.length; i++) {
+                    const [name, count] = rows[i];
+                    if (name && count) {
+                        nameToCountMap[name] = count;
+                    }
+                }
+
+                // 更新 personData 裡的每一筆資料，加上 count 欄位
+                personData.forEach(person => {
+                    person.count = nameToCountMap[person.name] || null;
+                });
+
+                // 將 personData 複製一份
+                originalPersonData = JSON.parse(JSON.stringify(personData));
+
+                // 呼叫你原本顯示畫面邏輯
+                renderPersonList();
+            });
+    }
+
+    function renderPersonList() {
+        // Generate the person list HTML
+        const personListElement = document.getElementById('person-list');
+        personListElement.innerHTML = ''; // 清空前次渲染
+        personData.forEach(person => {
+            // Calculate the current day and progress for this person
+            const { day, progress } = calculateDayDifference(person);
+
+            // Create the person item element
+            const personItem = document.createElement('div');
+            personItem.className = 'person-item';
+
+            const tooltip = document.createElement('div');
+            tooltip.className = 'tooltip';
+            tooltip.textContent = '點擊查看連署詳情';
+            personItem.appendChild(tooltip);
+
+            if (person.url) {
+                personItem.style.cursor = 'pointer';
+                personItem.addEventListener('click', () => {
+                    window.open(person.url, '_blank');
+                });
+            }
+
+            // Create the person name element
+            const personName = document.createElement('div');
+            personName.className = 'person-name';
+
+            const nameGroup = document.createElement('div');
+            nameGroup.className = 'name-text-group';
+
+            // 區域
+            const firstPart = document.createElement('span');
+            firstPart.textContent = person.name.substring(0, 3);
+            firstPart.className = 'person-name-area';
+
+            // 姓名
+            const secondPart = document.createElement('span');
+            secondPart.textContent = person.name.substring(3);
+            secondPart.className = 'person-name-fullname';
+
+            nameGroup.appendChild(firstPart);
+            nameGroup.appendChild(secondPart);
+
+            personName.appendChild(nameGroup);
+            //start
+
+            // 建立 icon container
+            const iconContainer = document.createElement('div');
+            iconContainer.className = 'icon-container';
+
+            // 當點擊 iconContainer 時阻止事件冒泡
+            iconContainer.addEventListener('click', (e) => {
+                e.stopPropagation();
+            });
+
+            // 定義 icon 資訊 (依需求替換 URL 與圖片來源)
+            const icons = [
+                { href: person.url, src: 'images/link.png', alt: '官方' },
+                { href: person.facebook, src: 'images/facebook.png', alt: 'FB' },
+                { href: person.instagram, src: 'images/instagram.png', alt: 'Instagram' },
+                { href: person.threads, src: 'images/threads.png', alt: 'Threads' },
+                { href: person.line, src: 'images/line.png', alt: 'Line' },
+                { href: person.x, src: 'images/twitter.png', alt: 'X' },
+                { href: person.youtube, src: 'images/youtube.png', alt: 'Youtube' }
+            ];
+
+            icons.forEach(iconData => {
+                if (iconData.href == "") {
+                    return;
+                }
+                const a = document.createElement('a');
+                a.href = iconData.href;
+                a.target = '_blank';
+                a.className = 'icon-link';
+
+                const img = document.createElement('img');
+                img.src = iconData.src;
+                img.alt = iconData.alt;
+                img.className = 'icon-image';
+
+                a.appendChild(img);
+                iconContainer.appendChild(a);
+            });
+
+            // 將 iconContainer 加入 personItem（右上角由 CSS 控制定位）
+            personName.appendChild(iconContainer);
+
+            //end
+
+            if (person.threshold && person.target) {
+                const goalInfo = document.createElement('div');
+                goalInfo.className = 'goal-info';
+
+                // 建立綠色的目前收件 span
+                const countSpan = document.createElement('span');
+                countSpan.className = 'count-info';
+
+                if (person.count) {
+                    const countNum = parseInt(person.count.replace(/,/g, '')); // 去除千分位
+                    if (!isNaN(countNum) && countNum > 0) {
+                        let current = 0;
+                        const duration = 800; // 動畫總長度 (ms)
+                        const frameRate = 30; // 幾毫秒更新一次
+                        const step = Math.ceil(countNum / (duration / frameRate));
+
+                        const interval = setInterval(() => {
+                            current += step;
+                            if (current >= countNum) {
+                                current = countNum;
+                                clearInterval(interval);
+                            }
+                            countSpan.textContent = `目前收件：${current.toLocaleString()}+　`;
+                        }, frameRate);
+                    } else {
+                        countSpan.textContent = `目前收件：統計中　`;
+                    }
+                }
+
+                const thresholdSpan = document.createElement('span');
+                thresholdSpan.className = 'min-threshold';
+                thresholdSpan.textContent = `門檻：${person.threshold.toLocaleString()}　`;
+
+                const targetSpan = document.createElement('span');
+                targetSpan.className = 'min-target';
+                targetSpan.textContent = `目標：${person.target.toLocaleString()}　`;
+
+                goalInfo.appendChild(countSpan);
+
+                goalInfo.append(thresholdSpan);
+                goalInfo.append(targetSpan);
+
+                personName.append(goalInfo);
+            }
+
+            personItem.appendChild(personName);
+
+            const progressBlock = document.createElement('div');
+            progressBlock.className = 'progress-block';
+
+            // Create the progress container
+            const progressContainer = document.createElement('div');
+            progressContainer.className = 'progress-container';
+
+            // Create the info container
+            const infoContainer = document.createElement('div');
+            infoContainer.className = 'info-container';
+
+            // ⬇️ 顯示目前收件數（從 Google Sheets 來）
+            if (person.count) {
+                // 👉 新增的收件進度條放這裡
+                const countNum = parseInt(person.count.replace(/,/g, '')); // 若有逗號分隔
+                const thresholdNum = typeof person.threshold === 'number' ? person.threshold : parseInt(person.threshold.toString().replace(/\D/g, ''));
+
+                const targetNum = parseInt(person.targetNum);
+                const thresholdPercent = Math.min((countNum / thresholdNum) * 100, 100);
+                const targetPercent = Math.min((countNum / targetNum) * 100, 100);
+
+                if (!isNaN(countNum) && !isNaN(thresholdNum) && thresholdNum > 0) {
+
+                    const receiptBarContainer = document.createElement('div');
+                    receiptBarContainer.className = 'progress-bar one-line';
+
+                    const receiptProgressBar = document.createElement('div');
+                    receiptProgressBar.className = 'progress-fill';
+                    receiptProgressBar.style.width = `0%`;
+
+                    const receiptText = document.createElement('div');
+                    receiptText.className = 'progress-text';
+                    if (countNum.toLocaleString() === "0") {
+                        receiptText.textContent = `統計中　`;
+                    } else {
+                        receiptText.textContent = `已收取：${countNum.toLocaleString()}+`;
+                    }
+
+                    const thresholdLine = document.createElement('div');
+                    thresholdLine.className = 'threshold-line';
+                    const thresholdPos = Math.min((thresholdNum / targetNum) * 100, 100);
+                    thresholdLine.style.left = `${thresholdPos}%`;
+
+                    const targetLine = document.createElement('div');
+                    targetLine.className = 'target-line';
+                    targetLine.style.left = `${99}%`;
+
+                    receiptBarContainer.appendChild(receiptProgressBar);
+                    receiptBarContainer.appendChild(receiptText);
+                    receiptBarContainer.appendChild(thresholdLine);
+                    receiptBarContainer.appendChild(targetLine);
+                    progressContainer.appendChild(receiptBarContainer);
+
+                    const labelProgress = document.createElement('div');
+                    labelProgress.className = 'day-info';
+                    labelProgress.textContent = `進度：0.0%`;
+                    infoContainer.appendChild(labelProgress);
+
+                    let curPercent = 0;
+                    const finalPercent = Math.min((countNum / targetNum) * 100, 100);
+                    const step = finalPercent / (800 / 30);
+
+                    const interval = setInterval(() => {
+                        curPercent += step;
+                        if (curPercent >= finalPercent) {
+                            curPercent = finalPercent;
+                            clearInterval(interval);
+                        }
+                        receiptProgressBar.style.width = `${curPercent}%`;
+                        labelProgress.textContent = `進度：${curPercent.toFixed(1)}%`;
+                    }, 30);
+
+                }
+            }
+
+            // Create the progress bar container
+            const progressBarContainer = document.createElement('div');
+            progressBarContainer.className = 'progress-bar';
+
+            // Create the progress bar
+            const progressBar = document.createElement('div');
+            progressBar.className = 'progress';
+            // 初始進度條設定為寬度 0
+            progressBar.style.width = `0%`; // 動畫從 0 開始
+            // progressBar.style.width = `${progress}%`;
+
+            // Create the day info element
+            const dayInfo = document.createElement('div');
+            dayInfo.className = 'day-info';
+            //dayInfo.textContent = day === '還未開始' ? day : `${day}/${person.totalDays}天`;
+
+            if (day === '還未開始') {
+                dayInfo.textContent = day;
+                progressBar.style.width = `0%`; // 不顯示進度
+            } else {
+                let currentPro = 0;
+                const frameRate = 30;
+                const stepPro = progress / (800 / frameRate);
+
+                const intervalPro = setInterval(() => {
+                    currentPro += stepPro;
+                    if (currentPro >= progress) {
+                        currentPro = progress;
+                        clearInterval(intervalPro);
+                    }
+
+                    progressBar.style.width = `${currentPro}%`;
+                }, frameRate);
+
+                dayInfo.textContent = `第0天/${person.totalDays}天`; // 初始為 0 天
+                let startDay = 0;
+                const finalDay = parseInt(day.replace('第', '').replace('天', ''));
+                const step = finalDay / (800 / frameRate);
+
+                const interval = setInterval(() => {
+                    startDay += step;
+                    if (startDay >= finalDay) {
+                        startDay = finalDay;
+                        clearInterval(interval);
+                    }
+
+                    dayInfo.textContent = `第${Math.floor(startDay)}天/${person.totalDays}天`;
+                }, frameRate);
+
+            }
+            // Append all elements
+            progressBarContainer.appendChild(progressBar);
+            progressContainer.appendChild(progressBarContainer);
+            infoContainer.appendChild(dayInfo);
+
+            progressBlock.appendChild(progressContainer);
+            progressBlock.appendChild(infoContainer);
+            personItem.appendChild(progressBlock);
+
+            personListElement.appendChild(personItem);
+        });
+    }
+
+    function filterAndSort() {
+        // const sortProcess = document.querySelector('.sort-process');
+        // const classList = sortProcess.classList;
+        // const isDesc = isFromSort ? !classList.contains('active') : classList.contains('active') && classList.contains('desc');
+        // const isAsc = isFromSort ? classList.contains('active') && classList.contains('desc') : classList.contains('active') && classList.contains('asc');
+        // const isToReset = isFromSort ? classList.contains('active') && classList.contains('asc') : !classList.contains('active');
+
+        const sortValue = document.querySelector('#sort').value;
+        const sortType = sortValue && sortValue.split('-')[0];
+        const sortOrder = sortValue.split('-')[1] === 'desc' ? -1 : 1;
+
+
+        // // ⬇️ 加入圖示切換函式
+        // function _updateIcons(state) {
+        //     const iconSort = document.querySelector('.icon-sort');
+        //     const iconUp = document.querySelector('.icon-up');
+        //     const iconDown = document.querySelector('.icon-down');
+
+        //     iconSort.style.display = 'none';
+        //     iconUp.style.display = 'none';
+        //     iconDown.style.display = 'none';
+
+        //     if (state === 'asc') {
+        //         iconUp.style.display = 'inline-block';
+        //     } else if (state === 'desc') {
+        //         iconDown.style.display = 'inline-block';
+        //     } else {
+        //         iconSort.style.display = 'inline-block';
+        //     }
+        // }
+
+        // function _resetClass() {
+        //     classList.remove('asc');
+        //     classList.remove('desc');
+        //     classList.remove('active');
+        //     _updateIcons(null); // ⬅️ 顯示 ⇅
+        // }
+
+        function _sortData(sortType, sortOrder) {
+            personData = personData.sort((a, b) => {
+                let compareA = '';
+                let compareB = '';
+
+                switch (sortType) {
+                    case 'targetNum':
+                    case 'threshold':
+                        compareA = parseInt(a.count) / a[sortType];
+                        compareB = parseInt(b.count) / b[sortType];
+                        break;
+                    case 'startDate':
+                        compareA = new Date(a[sortType]);
+                        compareB = new Date(b[sortType]);
+                        break;
+                }
+
+                return (compareA - compareB) * sortOrder;
+            });
+        }
+
+        function _filterName() {
+            const city = document.querySelector('#filter').value;
+
+            // reset
+            personData = JSON.parse(JSON.stringify(originalPersonData));
+            if (city !== 'all') {
+                personData = personData.filter(person => person.name.includes(city));
+            }
+        }
+
+        _filterName();
+        if (sortType)  {
+            console.log(sortType);
+
+            _sortData(sortType, sortOrder);
+        }
+
+        // if (isAsc) {
+        //     if (isFromSort) {
+        //         _resetClass();
+        //         classList.add('active', 'asc');
+        //         _updateIcons('asc');  // 顯示 ▲
+        //     }
+        //     _sortData(1);
+        // } else if (isDesc) {
+        //     if (isFromSort) {
+        //         _resetClass();
+        //         classList.add('active', 'desc');
+        //         _updateIcons('desc'); // 顯示 ▼
+        //     }
+        //     _sortData(-1);
+        // } else if (isToReset) {
+        //     _resetClass(); // 顯示 ⇅
+        // }
+
+        renderPersonList();
+    }
+
+    // document.querySelector('.sort-process').addEventListener('click', filterAndSort);
+    document.querySelector('#sort').addEventListener('change', filterAndSort);
+    document.querySelector('#filter').addEventListener('change', filterAndSort);
+});
+
+// 建立進場動畫卡片（一次性顯示）
+function showIntroCards() {
+    const introCards = [
+        {
+            date: '4/11',
+            weekday: '(五)',
+            title: '台東挖寶行動',
+            location: '四維路台東民進黨黨部前',
+            time: '19:00~19:10'
+          },
+          {
+            date: '4/12',
+            weekday: '(六)',
+            title: '花蓮市場掃街',
+            location: '花蓮市重慶市場',
+            time: '07:30~08:30'
+          },
+          {
+            date: '4/12',
+            weekday: '(六)',
+            title: '汐止羅免宣講',
+            location: '汐止區水返腳公園',
+            time: '14:00~14:15'
+          },
+          {
+            date: '4/12',
+            weekday: '(六)',
+            title: '人民是頭家新竹場',
+            location: '新竹市香山指澤宮廟埕',
+            time: '16:15~16:30'
+          },
+          {
+            date: '4/12',
+            weekday: '(六)',
+            title: '人民是頭家北屯場',
+            location: '台中舊社南興宮',
+            time: '19:00~19:30'
+          },
+          {
+            date: '4/13',
+            weekday: '(日)',
+            title: '苗栗羅免宣講',
+            location: '頭份市建國國小旁',
+            time: '10:30~10:45'
+          },
+          {
+            date: '4/13',
+            weekday: '(日)',
+            title: '板橋羅免宣講',
+            location: '永豐公園活動中心',
+            time: '13:30~14:00'
+          },
+          {
+            date: '4/13',
+            weekday: '(日)',
+            title: '文山羅免宣講',
+            location: '文山興隆公園',
+            time: '15:00~15:30'
+          },
+          {
+            date: '4/13',
+            weekday: '(日)',
+            title: '雙和羅免宣講',
+            location: '仁愛公園仁愛永貞路口',
+            time: '16:00~16:30'
+          }
+    ];
+  
+    const wrapper = document.createElement('div');
+    wrapper.id = 'entry-animation-wrapper';
+  
+    const cardsContainer = document.createElement('div');
+    cardsContainer.className = 'cards-container';
+    wrapper.appendChild(cardsContainer);
+  
+    const closeBtn = document.createElement('button');
+    closeBtn.id = 'close-entry-wrapper';
+    closeBtn.innerHTML = '&times;';
+  
+    const closeWrapper = () => {
+        wrapper.remove();
+        closeBtn.remove();
+        document.body.classList.remove('modal-open');
+    }
+  
+    closeBtn.addEventListener('click', closeWrapper);
+  
+    wrapper.addEventListener('click', (e) => {
+        if (e.target.id === 'entry-animation-wrapper') {
+            closeWrapper();
+        }
+    });
+  
+    document.body.appendChild(wrapper);
+    document.body.appendChild(closeBtn);
+    document.body.classList.add('modal-open');
+  
+    introCards.forEach((card, index) => {
+        const div = document.createElement('div');
+        div.className = 'event-card';
+        div.style.animationDelay = `${index * 0.1}s`; // 稍微加快動畫
+        div.innerHTML = `
+            <div class="event-header">
+                <div class="event-date">${card.date}</div>
+                <div class="event-weekday">${card.weekday}</div>
+                <div class="event-title">${card.title}</div>
+            </div>
+            <div class="event-location">${card.location}</div>
+            <div class="event-time">${card.time}</div>
+        `;
+        cardsContainer.appendChild(div);
+    });
+}
+document.addEventListener('DOMContentLoaded', showIntroCards);

--- a/styles/styleUat.css
+++ b/styles/styleUat.css
@@ -1,0 +1,571 @@
+body {
+    font-family: 'Microsoft JhengHei', Arial, sans-serif;
+    margin: 0;
+    padding: 20px;
+    background: linear-gradient(to bottom, #e9f2e3, #f7e9d3);
+    background-color: #f5f5f5;
+}
+
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+    background-color: white;
+    border-radius: 10px;
+    padding: 20px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+
+h1 {
+    color: #8B0000;
+    font-size: 24px;
+    margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.notice {
+    font-size: 14px;
+    color: #cc0000;
+    margin-top: 10px;
+    line-height: 1.6;
+    background-color: #fff4f4;
+    padding: 10px 15px;
+    border-left: 4px solid #cc0000;
+    border-radius: 6px;
+}
+
+.hourglass {
+    font-size: 28px;
+}
+
+.subtitle {
+    color: #333;
+    font-size: 16px;
+    margin-bottom: 20px;
+}
+
+/* 資料表單主div */
+.person-list {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+}
+
+@media (max-width: 600px) {
+    .person-list {
+        grid-template-columns: 1fr;
+    }
+}
+
+.person-item {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 5px;
+    background-color: #fff;
+    border-radius: 12px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    padding: 12px;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    transform-style: preserve-3d;
+    perspective: 1000px;
+    position: relative;
+}
+
+.person-item:hover {
+    transform: translateY(-8px) rotateX(3deg) rotateY(2deg);
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+    background-color: #fdf5f1;
+}
+
+.tooltip {
+    position: absolute;
+    top: -30px;
+    right: 5px;
+    background-color: #333;  /* 淡粉紅色 */
+    color: #fff;
+    padding: 6px 12px;
+    font-size: 14px;
+    border-radius: 4px 4px 0 0;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+  }
+
+  .tooltip::after {
+    content: "";
+    position: absolute;
+    bottom: -10px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 10px 10px 0 10px;
+    border-style: solid;
+    border-color: #333 transparent transparent transparent;
+  }
+
+  .person-item:hover .tooltip {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+.person-item:hover .tooltip {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.person-name {
+    margin-top: -5px;
+    font-size: 16px;
+    display: flex;
+    justify-content: space-between; /* 左右分散 */
+    align-items: center;
+    flex-wrap: wrap; /* 這行讓 icon 會換行 */
+    position: relative;
+  }
+
+/* 包住區域和人名的容器 */
+.name-text-group {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+.person-name-area {
+    background-color: #FAF3E0; /* 淡粉色背景 */
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 14px;
+    font-weight: 500;
+  }
+
+  .person-name-fullname {
+    margin-left: 10px;
+    font-weight: bold;
+    font-size: 16px;
+    color: #333; /* 深灰色 */
+  }
+
+.progress-block {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 10px;
+}
+
+.progress-container {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    flex: 1;
+    min-width: 0;
+    width: 68%;
+}
+
+.info-container {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    justify-content: space-between;
+    min-width: 100px; /* 可依需要調整 */
+    width: 32%;
+}
+
+/* 收件數量的樣式 */
+.count-info {
+    font-size: 13px;
+    color: #006400;
+    margin-top: 4px;
+}
+
+.min-threshold {
+    color: #ff9800;
+}
+
+.min-target {
+    font-weight:bold;
+    color: #ff0000;
+    /* color: #dd8a0e; */
+}
+
+/* 天數讀取條樣式 */
+.progress-bar {
+    flex-grow: 1;
+    height: 20px;
+    background-color: #f0e6d2;
+    border-radius: 8px;
+    overflow: hidden;
+    position: relative;
+    margin-top: 2px;
+}
+
+.progress {
+    height: 100%;
+    background: linear-gradient(90deg, #cc4b4b, #e39393);
+    border-radius: 8px 0 0 8px;
+}
+
+.progress-bar.one-line {
+    position: relative;
+    background-color: #f0e6d2;
+    height: 20px;
+    border-radius: 8px 0 0 8px;
+    overflow: hidden;
+}
+
+.progress-fill {
+    position: absolute;
+    height: 100%;
+    background: linear-gradient(90deg, #4caf50, #81c784);
+    left: 0;
+    top: 0;
+    width: 0%;
+    z-index: 1;
+    transition: width 0.3s ease-out;
+}
+
+.progress-text {
+    position: absolute;
+    left: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 13px;
+    color: #000;
+    z-index: 2;
+    pointer-events: none;
+}
+
+.threshold-line {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background-color: #ff9800;
+    z-index: 3;
+}
+
+.target-line {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background-color: #ff0000;
+    z-index: 3;
+}
+
+/* 讀取條後面的文字樣式 */
+.day-info {
+    font-size: 14px;
+    white-space: nowrap;
+}
+
+/* 門檻目標的樣式 */
+.goal-info {
+    font-size: 13px;
+    color: #555;
+    margin-top: 2px;
+    margin-bottom: 4px;
+}
+
+/* 下方資訊所使用的樣式 */
+.info-section {
+    margin-top: 20px;
+    padding-top: 15px;
+    border-top: 1px solid #eee;
+}
+
+.info-title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: #333;
+    font-size: 18px;
+    margin-bottom: 10px;
+}
+
+.info-title .sun {
+    color: #FFD700;
+    font-size: 24px;
+}
+
+.info-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px 30px;
+}
+
+@media (max-width: 600px) {
+    .info-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+.info-item {
+    display: flex;
+    margin-bottom: 8px;
+    align-items: center;
+}
+
+.check-mark {
+    color: #4CAF50;
+    font-size: 20px;
+    margin-right: 10px;
+}
+
+.cross-mark {
+    color: #F44336;
+    font-size: 20px;
+    margin-right: 10px;
+}
+
+.important {
+    color: #cc0000;
+    font-weight: bold;
+}
+
+.icon-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0px;
+}
+
+.icon-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6px;
+    border-radius: 4px;
+    border: 1.5px solid transparent;
+    transition: border 0.2s ease;
+}
+
+.icon-link:hover {
+    border: 1.5px solid #000;
+}
+
+.icon-image {
+    width: 20px;
+    height: 20px;
+    display: block;
+    pointer-events: none;
+}
+
+.filter-sort {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 15px;
+    flex-wrap: wrap;
+}
+
+.general-select {
+    height: 34px;
+    background-color: #fdf7ec;
+    border: 1.5px solid #bfa88b;
+    padding: 6px 6px 6px 10px;
+    border-radius: 8px;
+    font-size: 14px;
+    color: #5a4e3c;
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    background-size: 14px;
+    transition: border 0.2s ease;
+    cursor: pointer;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.general-select:focus {
+    outline: none;
+    border-color: #9c7f5d;
+}
+
+.general-select.no-icon {
+    -moz-appearance:none; /* Firefox */
+    -webkit-appearance:none; /* Safari and Chrome */
+    appearance:none;
+}
+
+.sort-process {
+    cursor: pointer;
+    font-size: 14px;
+    background-color: #fdf7ec;
+    color: #5a4e3c;
+    padding: 5px 10px;
+    border: 1.5px solid #bfa88b;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.sort-process:hover {
+    background-color: #f2e8d8;
+    border-color: #9c7f5d;
+}
+
+.sort-process.active {
+    font-weight: bold;
+    background-color: #f2e8d8;
+    border-color: #9c7f5d;
+}
+
+.sort-icon {
+    position: relative;
+}
+
+.fa-sort {
+    opacity: 0.5;
+}
+
+.sort-process .fa-sort-up,
+.sort-process .fa-sort-down {
+    display: none;
+    position: absolute;
+    left: 0;
+    top: 0;
+}
+
+.sort-process.active {
+    font-weight: bold;
+    color: #333;
+}
+
+.sort-process.active.asc .fa-sort-up {
+    display: inline-block;
+}
+
+.sort-process.active.desc .fa-sort-down {
+    display: inline-block;
+}
+
+.icon {
+    font-size: 14px;
+    margin-left: 4px;
+    color: #333;
+}
+
+.icon-sort {
+    opacity: 0.6;
+}
+
+.icon-up,
+.icon-down {
+    opacity: 1;
+    font-size: 16px;
+}
+
+body.modal-open {
+    overflow: hidden !important;
+    height: 100vh;
+}
+
+#entry-animation-wrapper {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 9999;
+    background-color: rgba(255, 255, 255, 0.85);
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding: 80px 0 20px;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.cards-container {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr); /* 固定2列 */
+    gap: 16px; /* 減少間距 */
+    width: 90%;
+    max-width: 800px;
+    padding: 0 10px;
+}
+
+@media (max-width: 600px) {
+    .cards-container {
+        grid-template-columns: 1fr; /* 手機版1列 */
+        width: 95%;
+    }
+}
+
+.event-card {
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    background-color: #fff;
+    width: 100%;
+    margin: 0;
+    animation: dropDown 0.6s ease forwards;
+    opacity: 0;
+    transform: translateY(-30px);
+}
+
+.event-header {
+    background-color: #295939;
+    color: white;
+    padding: 8px 12px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: bold;
+    font-size: 16px;
+    flex-wrap: wrap;
+}
+
+.event-date {
+    font-size: 18px;
+}
+
+.event-weekday {
+    font-size: 16px;
+}
+
+.event-title {
+    flex: 1;
+    font-size: 16px;
+}
+
+.event-location,
+.event-time {
+    background-color: #f5f0e6;
+    color: #333;
+    padding: 6px 12px;
+    font-size: 14px;
+    border-top: 1px solid #ddd;
+}
+
+.event-location {
+    font-weight: 500;
+}
+
+#close-entry-wrapper {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    z-index: 10000;
+    background: #fff;
+    color: #333;
+    border: none;
+    font-size: 20px;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+@keyframes dropDown {
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}


### PR DESCRIPTION
新增了一個名為 `indexUat.html` 的 HTML 檔案，包含設定文件類型、語言屬性、meta 標籤、JSON-LD 結構化數據、favicon、CSS 樣式表、Google Analytics 追蹤代碼及主要內容。 新增了多個 JavaScript 函數和事件監聽器，用於頁面加載、日期計算、數據獲取、列表渲染、篩選和排序等功能。 新增了大量 CSS 樣式，用於設定頁面佈局、字體、顏色、背景、邊距、陰影、過渡效果等，並包含進場動畫卡片的樣式和動畫。