### PR TITLE
fix: 更新新竹市鄭正鈐的總天數為57天

### DIFF
--- a/personData.json
+++ b/personData.json
@@ -291,7 +291,7 @@
         "name": "新竹市鄭正鈐",
         "status": "第14天",
         "startDate": "2025-03-05",
-        "totalDays": 40,
+        "totalDays": 57,
         "threshold": 35465,
         "target": "5萬",
         "targetNum": 50000,


### PR DESCRIPTION
fix: 更新新竹市鄭正鈐的總天數為57天